### PR TITLE
🚸 Remove false positive (www.)ip-api.com

### DIFF
--- a/hosts
+++ b/hosts
@@ -649,7 +649,6 @@
 127.0.0.1 installer.filebulldog.com
 127.0.0.1 instana.io
 127.0.0.1 iosexy.com
-127.0.0.1 ip-api.com
 127.0.0.1 iplocation-api.wp.trt.com.tr
 127.0.0.1 is.sabah.com.tr
 127.0.0.1 istat.izlesene.com


### PR DESCRIPTION
This PR removes (www.)ip-api.com which is a false positive (and I really don't know WHY and HOW children should or would use this domain!? 😜). It has been also removed from other major blocklists:
https://blocklist-tools.developerdan.com/entries/search?q=ip-api.com

I will also inform the owners of the remaining lists to remove this domain(s).

Because of this blocklist entry, someone isn't able to gather ASN infos for a given IP or domain 😞 
```
# https://github.com/trimstray/the-book-of-secret-knowledge#shell-functions-toc
function getASN () {
    local _ip="$1";
    local _curl_base="curl --request GET";
    local _timeout="15";
    _asn=$($_curl_base -ks -m "$_timeout" "http://ip-api.com/line/${_ip}?fields=as");
    _state=$(echo $?);
    if [[ -z "$_ip" ]] || [[ "$_ip" == "null" ]] || [[ "$_state" -ne 0 ]]; then
        echo -en "Unsuccessful ASN gathering.\\n";
    else
        echo -en "$_ip > $_asn\\n";
    fi
}
```