### PR TITLE
Update hosts

### DIFF
--- a/hosts
+++ b/hosts
@@ -386,7 +386,6 @@
 127.0.0.1 bkrtx.com
 127.0.0.1 block.s2block.com
 127.0.0.1 bluekai.com
-127.0.0.1 bnc.lt
 127.0.0.1 bo.facesbet.com
 127.0.0.1 boomads.com
 127.0.0.1 bornobid.com
@@ -411,7 +410,6 @@
 127.0.0.1 cdn.bispd.com
 127.0.0.1 cdn.bisrv.com
 127.0.0.1 cdn.cdndp.com
-127.0.0.1 cdn.cookielaw.org
 127.0.0.1 cdn.download.sweetpacks.com
 127.0.0.1 cdn.dpdownload.com
 127.0.0.1 cdn.elasticad.net
@@ -476,7 +474,6 @@
 127.0.0.1 cookie-cdn.cookiepro.com
 127.0.0.1 cookiebar.eticaret.com
 127.0.0.1 cookiebot.com
-127.0.0.1 cookielaw.org
 127.0.0.1 cookiepro.com
 127.0.0.1 cookieseal.com
 127.0.0.1 core.insightexpressai.com
@@ -899,7 +896,6 @@
 127.0.0.1 reali.st
 127.0.0.1 realist.gen.tr
 127.0.0.1 rebrand.ly
-127.0.0.1 redirector.gvt1.com
 127.0.0.1 ref.gitadres.com
 127.0.0.1 refbanners.website
 127.0.0.1 referrer.website


### PR DESCRIPTION
All of them are breaking functionalities of websites or softwares. When I checked if they're blocked in any other lists, I've seen them removed or not included in those.
bnc.lt domain is used within deeplinking apps
cookielaw.org is a service positioned for GPDR consent nag screen, which breaks websites that use them
gvt1.com is used for google video transcoder, this is used for both websites and even some chrome functionalities. this has been removed from most of the lists over time.