### PR TITLE
Olası Yanlış Engelleme Kuralı Silindi

### DIFF
--- a/hosts
+++ b/hosts
@@ -662,7 +662,6 @@
 127.0.0.1 instana.io
 127.0.0.1 iosexy.com
 127.0.0.1 ipcheck.tmgrup.com.tr
-127.0.0.1 ipify.org
 127.0.0.1 iplocation-api.wp.trt.com.tr
 127.0.0.1 is.sabah.com.tr
 127.0.0.1 istat.izlesene.com


### PR DESCRIPTION
https://github.com/bkrucarci/turk-adlist/commit/3ad9d1030d72449cf306cf49f4936e3e814204f2 commiti ile eklenen `ipify.org` kaldırıldı..

Vestel Akıllı Televizyon uygulama mağazasına girişini engelliyor :)